### PR TITLE
Update xclbin filename to fix error std::bad_alloc

### DIFF
--- a/Vitis_Platform_Creation/Introduction/02-Edge-AI-ZCU104/step4.md
+++ b/Vitis_Platform_Creation/Introduction/02-Edge-AI-ZCU104/step4.md
@@ -154,7 +154,7 @@ Vector addition is the simplest acceleration PL kernel. Vitis can create this ap
    - Run vadd application
 
    ```bash
-   ./vadd vadd.xclbin
+   ./vadd binary_container_1.xclbin
    ```
 
    - It should show program prints and XRT debug info.


### PR DESCRIPTION
Update vadd.xclbin to binary_container_1.xclbin to fix error: `terminate called after throwing an instance of 'std::bad_alloc' ` 
Thanks to the feedback from @ksstms at https://github.com/Xilinx/Vitis-In-Depth-Tutorial/issues/34